### PR TITLE
Passando $charset para a função curlConnection

### DIFF
--- a/src/Cassioalmeida/Pagsegurotransparente/HttpConnection.php
+++ b/src/Cassioalmeida/Pagsegurotransparente/HttpConnection.php
@@ -124,7 +124,7 @@ class HttpConnection
 
         $options = array(
             CURLOPT_HTTPHEADER => array(
-                "Content-Type: application/x-www-form-urlencoded; charset=" . $charset,
+                "Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1",
                 $contentLength
             ),
             CURLOPT_URL => $url,

--- a/src/Cassioalmeida/Pagsegurotransparente/HttpConnection.php
+++ b/src/Cassioalmeida/Pagsegurotransparente/HttpConnection.php
@@ -76,7 +76,7 @@ class HttpConnection
      * @return bool
      * @throws Exception
      */
-    public function post($url, array $data = null, $timeout = null, $charset = null) {
+    public function post($url, array $data = null, $timeout = null, $charset = 'ISO-8859-1') {
         return $this->curlConnection('POST', $url, $data, $timeout, $charset);
     }
 
@@ -90,7 +90,7 @@ class HttpConnection
      * @return bool
      * @throws Exception
      */
-    public function get($url, array $data = null, $timeout = null, $charset = null) {
+    public function get($url, array $data = null, $timeout = null, $charset = 'ISO-8859-1') {
         return $this->curlConnection('GET', $url, $data, $timeout, $charset);
     }
 
@@ -124,7 +124,7 @@ class HttpConnection
 
         $options = array(
             CURLOPT_HTTPHEADER => array(
-                "Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1",
+                "Content-Type: application/x-www-form-urlencoded; charset=" . $charset,
                 $contentLength
             ),
             CURLOPT_URL => $url,


### PR DESCRIPTION
O $charset vem sempre nulo e com isso da erro na resposta do pagSeguro, colocando o charset=ISO-8859-1 direto resolve o problema.